### PR TITLE
Renamed commitMessage to mergeCommitMessage in SetAutoComplete.

### DIFF
--- a/task/createPullRequest.ps1
+++ b/task/createPullRequest.ps1
@@ -545,7 +545,7 @@ function SetAutoComplete {
         mergeStrategy       = "$mergeStrategy" 
         deleteSourceBranch  = "$deleteSourch"
         transitionWorkItems = "$transitionWorkItems"
-        commitMessage       = "$commitMessage"
+        mergeCommitMessage  = "$commitMessage"
     }
     $body.completionOptions = $options
 


### PR DESCRIPTION
Azure DevOps GitPullRequestCompletionOptions: 
mergeCommitMessage - If set, this will be used as the commit message of the merge commit.