### PR TITLE
Added step to pass pullRequestId back to Azure DevOps

### DIFF
--- a/task/createPullRequest.ps1
+++ b/task/createPullRequest.ps1
@@ -303,6 +303,9 @@ function CreateAzureDevOpsPullRequest() {
             Write-Host "*************************"
             Write-Host "Pull Request $pullRequestId created."
             
+            # Pass pullRequestId back to Azure DevOps for consumption by other pipeline tasks
+            write-host "##vso[task.setvariable variable=pullRequestId]$pullRequestId"
+
             $currentUserId = $response.createdBy.id
 
             # If set auto aomplete is true 

--- a/task/createPullRequest.ps1
+++ b/task/createPullRequest.ps1
@@ -16,7 +16,8 @@ function RunTask {
         [bool]$linkWorkItems,
         [string]$teamProject,
         [string]$repositoryName,
-        [string]$githubRepository
+        [string]$githubRepository,
+        [bool]$passPullRequestIdBackToADO
     )
 
     Trace-VstsEnteringInvocation $MyInvocation
@@ -38,6 +39,7 @@ function RunTask {
         $teamProject = Get-VstsInput -Name 'projectId' 
         $repositoryName = Get-VstsInput -Name 'gitRepositoryId'
         $githubRepository = Get-VstsInput -Name 'githubRepository'
+        $passPullRequestIdBackToADO = Get-VstsInput -Name 'passPullRequestIdBackToADO' -AsBool
         
         if ($repositoryName -eq "" -or $repositoryName -eq "currentBuild") {
             $teamProject = $env:System_TeamProject
@@ -49,7 +51,7 @@ function RunTask {
       
         # If the target branch is only one branch
         if (!$targetBranch.Contains('*')) {
-            CreatePullRequest -teamProject $teamProject -repositoryName $repositoryName -sourceBranch $sourceBranch -targetBranch $targetBranch -title $title -description $description -reviewers $reviewers -repoType $repoType -isDraft $isDraft -autoComplete $autoComplete -mergeStrategy $mergeStrategy -deleteSourch $deleteSourch -commitMessage $commitMessage -transitionWorkItems $transitionWorkItems -linkWorkItems $linkWorkItems -githubRepository $githubRepository
+            CreatePullRequest -teamProject $teamProject -repositoryName $repositoryName -sourceBranch $sourceBranch -targetBranch $targetBranch -title $title -description $description -reviewers $reviewers -repoType $repoType -isDraft $isDraft -autoComplete $autoComplete -mergeStrategy $mergeStrategy -deleteSourch $deleteSourch -commitMessage $commitMessage -transitionWorkItems $transitionWorkItems -linkWorkItems $linkWorkItems -githubRepository $githubRepository -passPullRequestIdBackToADO $passPullRequestIdBackToADO
         }
 
         # If is multi-target branch, like feature/*
@@ -60,7 +62,7 @@ function RunTask {
                 $refs = Invoke-RestMethod -Uri $url -Method Get -Headers $header -ContentType "application/json"
                 $targetBranches = ($refs.value.Where({ $_.name -match "$($targetBranch.Replace('*',''))" })).name
                 foreach($targetBranch in $targetBranches) {
-                    CreatePullRequest -teamProject $teamProject -repositoryName $repositoryName -sourceBranch $sourceBranch -targetBranch $targetBranch -title $title -description $description -reviewers $reviewers -repoType $repoType -isDraft $isDraft -autoComplete $autoComplete -mergeStrategy $mergeStrategy -deleteSourch $deleteSourch -commitMessage $commitMessage -transitionWorkItems $transitionWorkItems -linkWorkItems $linkWorkItems -githubRepository $githubRepository 
+                    CreatePullRequest -teamProject $teamProject -repositoryName $repositoryName -sourceBranch $sourceBranch -targetBranch $targetBranch -title $title -description $description -reviewers $reviewers -repoType $repoType -isDraft $isDraft -autoComplete $autoComplete -mergeStrategy $mergeStrategy -deleteSourch $deleteSourch -commitMessage $commitMessage -transitionWorkItems $transitionWorkItems -linkWorkItems $linkWorkItems -githubRepository $githubRepository -passPullRequestIdBackToADO $false
                 }  
             }
             else {
@@ -80,7 +82,7 @@ function RunTask {
                 $branches = Invoke-RestMethod -Uri $url -Method Get -ContentType "application/json" -Headers $header
                 $targetBranches = $branches.name.Where({ $_ -match "$($targetBranch.Replace('*',''))" })
                 foreach($targetBranch in $targetBranches) {
-                    CreatePullRequest -teamProject $teamProject -repositoryName $repositoryName -sourceBranch $sourceBranch -targetBranch $targetBranch -title $title -description $description -reviewers $reviewers -repoType $repoType -isDraft $isDraft -autoComplete $autoComplete -mergeStrategy $mergeStrategy -deleteSourch $deleteSourch -commitMessage $commitMessage -transitionWorkItems $transitionWorkItems -linkWorkItems $linkWorkItems -githubRepository $githubRepository 
+                    CreatePullRequest -teamProject $teamProject -repositoryName $repositoryName -sourceBranch $sourceBranch -targetBranch $targetBranch -title $title -description $description -reviewers $reviewers -repoType $repoType -isDraft $isDraft -autoComplete $autoComplete -mergeStrategy $mergeStrategy -deleteSourch $deleteSourch -commitMessage $commitMessage -transitionWorkItems $transitionWorkItems -linkWorkItems $linkWorkItems -githubRepository $githubRepository -passPullRequestIdBackToADO $false
                 }  
             }
         }
@@ -110,16 +112,17 @@ function CreatePullRequest() {
         [bool]$linkWorkItems,
         [string]$teamProject,
         [string]$repositoryName,
-        [string]$githubRepository
+        [string]$githubRepository,
+        [bool]$passPullRequestIdBackToADO
     )
 
     if ($repoType -eq "Azure DevOps") { 
-        CreateAzureDevOpsPullRequest -teamProject $teamProject -repositoryName $repositoryName -sourceBranch $sourceBranch -targetBranch $targetBranch -title $title -description $description -reviewers $reviewers -isDraft $isDraft -autoComplete $autoComplete -mergeStrategy $mergeStrategy -deleteSourch $deleteSourch -commitMessage $commitMessage -transitionWorkItems $transitionWorkItems -linkWorkItems $linkWorkItems
+        CreateAzureDevOpsPullRequest -teamProject $teamProject -repositoryName $repositoryName -sourceBranch $sourceBranch -targetBranch $targetBranch -title $title -description $description -reviewers $reviewers -isDraft $isDraft -autoComplete $autoComplete -mergeStrategy $mergeStrategy -deleteSourch $deleteSourch -commitMessage $commitMessage -transitionWorkItems $transitionWorkItems -linkWorkItems $linkWorkItems -passPullRequestIdBackToADO $passPullRequestIdBackToADO
     }
 
     else {
         # Is GitHub repository
-        CreateGitHubPullRequest -sourceBranch $sourceBranch -targetBranch $targetBranch -title $title -description $description -reviewers $reviewers -isDraft $isDraft -githubRepository $githubRepository
+        CreateGitHubPullRequest -sourceBranch $sourceBranch -targetBranch $targetBranch -title $title -description $description -reviewers $reviewers -isDraft $isDraft -githubRepository $githubRepository -passPullRequestIdBackToADO $passPullRequestIdBackToADO
     }
 }
 
@@ -134,7 +137,8 @@ function CreateGitHubPullRequest() {
         [string]$description,
         [string]$reviewers,
         [bool]$isDraft,
-        [string]$githubRepository
+        [string]$githubRepository,
+        [bool]$passPullRequestIdBackToADO
     )
 
     Write-Host "The Source Branch is: $sourceBranch"
@@ -179,6 +183,12 @@ function CreateGitHubPullRequest() {
             Write-Host "******** Success ********"
             Write-Host "*************************"
             Write-Host "Pull Request $($response.number) created."
+
+            if ($passPullRequestIdBackToADO) {
+                # Pass pullRequestId back to Azure DevOps for consumption by other pipeline tasks
+                write-host "##vso[task.setvariable variable=pullRequestId]$($response.number)"
+            }
+
             # If the reviewers not null so add the reviewers to the PR
             if ($reviewers -ne "") {
                 CreateGitHubReviewers -reviewers $reviewers -token $token -prNumber $response.number
@@ -247,7 +257,8 @@ function CreateAzureDevOpsPullRequest() {
         [bool]$transitionWorkItems,
         [bool]$linkWorkItems,
         [string]$teamProject,
-        [string]$repositoryName
+        [string]$repositoryName,
+        [bool]$passPullRequestIdBackToADO
     )
 
     if (!$sourceBranch.Contains("refs")) {
@@ -303,8 +314,10 @@ function CreateAzureDevOpsPullRequest() {
             Write-Host "*************************"
             Write-Host "Pull Request $pullRequestId created."
             
-            # Pass pullRequestId back to Azure DevOps for consumption by other pipeline tasks
-            write-host "##vso[task.setvariable variable=pullRequestId]$pullRequestId"
+            if ($passPullRequestIdBackToADO) {
+                # Pass pullRequestId back to Azure DevOps for consumption by other pipeline tasks
+                write-host "##vso[task.setvariable variable=pullRequestId]$pullRequestId"
+            }
 
             $currentUserId = $response.createdBy.id
 

--- a/task/task.json
+++ b/task/task.json
@@ -155,8 +155,7 @@
       "label": "Pass Pull Request ID back to Azure DevOps as a variable",
       "defaultValue": false,
       "required": false,
-      "helpMarkDown": "If checked, the Pull Request ID will be passed back to Azure DevOps for use in other pipeline tasks.  The variable can be referenced as '$(pullRequestId)'.  Note this feature is disabled if multiple target branches are specified with a wildcard (e.g. feature/*)",
-      "visibleRule": "repoType=Azure DevOps"
+      "helpMarkDown": "If checked, the Pull Request ID will be passed back to Azure DevOps for use in other pipeline tasks.  The variable can be referenced as '$(pullRequestId)'.  Note this feature is disabled if multiple target branches are specified with a wildcard (e.g. feature/*)"
     },
     {
       "name": "autoComplete",

--- a/task/task.json
+++ b/task/task.json
@@ -155,7 +155,7 @@
       "label": "Pass Pull Request ID back to Azure DevOps as a variable",
       "defaultValue": false,
       "required": false,
-      "helpMarkDown": "If checked, the Pull Request ID will be passed back to Azure DevOps for use in other pipeline tasks.  The variable can be referenced as $(pullRequestId)",
+      "helpMarkDown": "If checked, the Pull Request ID will be passed back to Azure DevOps for use in other pipeline tasks.  The variable can be referenced as $(pullRequestId).  Note this feature is disabled if multiple target branches are specified with a wildcard (e.g. feature/*)",
       "visibleRule": "repoType=Azure DevOps"
     },
     {

--- a/task/task.json
+++ b/task/task.json
@@ -155,7 +155,7 @@
       "label": "Pass Pull Request ID back to Azure DevOps as a variable",
       "defaultValue": false,
       "required": false,
-      "helpMarkDown": "If checked, the Pull Request ID will be passed back to Azure DevOps for use in other pipeline tasks.  The variable can be referenced as $(pullRequestId).  Note this feature is disabled if multiple target branches are specified with a wildcard (e.g. feature/*)",
+      "helpMarkDown": "If checked, the Pull Request ID will be passed back to Azure DevOps for use in other pipeline tasks.  The variable can be referenced as '$(pullRequestId)'.  Note this feature is disabled if multiple target branches are specified with a wildcard (e.g. feature/*)",
       "visibleRule": "repoType=Azure DevOps"
     },
     {

--- a/task/task.json
+++ b/task/task.json
@@ -11,7 +11,7 @@
   "version": {
     "Major": 1,
     "Minor": 2,
-    "Patch": 41
+    "Patch": 42
   },
   "instanceNameFormat": "Create Pull Request",
   "groups": [
@@ -147,6 +147,15 @@
       "defaultValue": true,
       "required": false,
       "helpMarkDown": "If checked, all the work items that linked to the commits will be linked also to the PullRequest.",
+      "visibleRule": "repoType=Azure DevOps"
+    },
+    {
+      "name": "passPullRequestIdBackToADO",
+      "type": "boolean",
+      "label": "Pass Pull Request ID back to Azure DevOps as a variable",
+      "defaultValue": false,
+      "required": false,
+      "helpMarkDown": "If checked, the Pull Request ID will be passed back to Azure DevOps for use in other pipeline tasks.  The variable can be referenced as $(pullRequestId)",
       "visibleRule": "repoType=Azure DevOps"
     },
     {


### PR DESCRIPTION
so that it can be used by other pipeline tasks.  For example, a subsequent task could post a link to the pull request in Slack alerting others to approve.