### PR TITLE
Fix for setting pull request id value in next stages of azure devops pipeline

### DIFF
--- a/task/createPullRequest.ps1
+++ b/task/createPullRequest.ps1
@@ -83,7 +83,7 @@ function RunTask {
         }
 
         foreach($branch in $targetBranches) {
-            CreatePullRequest -teamProject $teamProject -repositoryName $repositoryName -sourceBranch $sourceBranch -targetBranch $branch -title $title -description $description -reviewers $reviewers -repoType $repoType -isDraft $isDraft -autoComplete $autoComplete -mergeStrategy $mergeStrategy -deleteSourch $deleteSourch -commitMessage $commitMessage -transitionWorkItems $transitionWorkItems -linkWorkItems $linkWorkItems -githubRepository $githubRepository -passPullRequestIdBackToADO $false
+            CreatePullRequest -teamProject $teamProject -repositoryName $repositoryName -sourceBranch $sourceBranch -targetBranch $branch -title $title -description $description -reviewers $reviewers -repoType $repoType -isDraft $isDraft -autoComplete $autoComplete -mergeStrategy $mergeStrategy -deleteSourch $deleteSourch -commitMessage $commitMessage -transitionWorkItems $transitionWorkItems -linkWorkItems $linkWorkItems -githubRepository $githubRepository -passPullRequestIdBackToADO $passPullRequestIdBackToADO
         }  
     }
 

--- a/task/createPullRequest.ps1
+++ b/task/createPullRequest.ps1
@@ -52,6 +52,7 @@ function RunTask {
 
         # If is multi-target branch, like release/*
         if ($targetBranch.Contains('*')) {
+            $passPullRequestIdBackToADO = $false
             if($repoType -eq "Azure DevOps") {
                 $url = "$env:System_TeamFoundationCollectionUri$($teamProject)/_apis/git/repositories/$($repositoryName)/refs?api-version=4.1"
                 $header = @{ Authorization = "Bearer $env:System_AccessToken" }
@@ -79,6 +80,7 @@ function RunTask {
 
         # If is multi-target branch, like master;feature
         elseif($targetBranch.Contains(';')) {
+            $passPullRequestIdBackToADO = $false
             $targetBranches = $targetBranch.Split(';')
         }
 


### PR DESCRIPTION
Not sure if it was inteded or not but after commit https://github.com/shayki5/azure-devops-create-pr-task/commit/8197a04555c104dab74f8c37f3bd2f580210c170 flag passPullRequestIdBackToAdo is not populated down anymore which cause in atleast our case several pipelines to stopped working beacuse we are using pull request id in next steps of the pipeline.


