### PR TITLE
Added support for `[BRANCH_NAME]` in `title` input

### DIFF
--- a/task/createPullRequest.ps1
+++ b/task/createPullRequest.ps1
@@ -98,6 +98,11 @@ function RunTask {
             $pullRequestTitle = $title.Replace('[BRANCH_NAME]', $branch.Replace('refs/heads/',''))
             CreatePullRequest -teamProject $teamProject -repositoryName $repositoryName -sourceBranch $sourceBranch -targetBranch $branch -title $pullRequestTitle -description $description -reviewers $reviewers -repoType $repoType -isDraft $isDraft -autoComplete $autoComplete -mergeStrategy $mergeStrategy -deleteSourch $deleteSourch -commitMessage $commitMessage -transitionWorkItems $transitionWorkItems -linkWorkItems $linkWorkItems -githubRepository $githubRepository -passPullRequestIdBackToADO $passPullRequestIdBackToADO -isForked $isForked -bypassPolicy $bypassPolicy -bypassReason $bypassReason
         }
+
+        if ($passPullRequestIdBackToADO) {
+            # Pass pullRequestId back to Azure DevOps for consumption by other pipeline tasks
+            write-host "##vso[task.setvariable variable=pullRequestId]$(($global:pullRequestIds -join ';').TrimEnd(';'))"
+        }
     }
 
     finally {

--- a/task/createPullRequest.ps1
+++ b/task/createPullRequest.ps1
@@ -94,6 +94,7 @@ function RunTask {
         }
 
         foreach($branch in $targetBranches) {
+            $title = $title.Replace("[BRANCH_NAME]", $branch)
             CreatePullRequest -teamProject $teamProject -repositoryName $repositoryName -sourceBranch $sourceBranch -targetBranch $branch -title $title -description $description -reviewers $reviewers -repoType $repoType -isDraft $isDraft -autoComplete $autoComplete -mergeStrategy $mergeStrategy -deleteSourch $deleteSourch -commitMessage $commitMessage -transitionWorkItems $transitionWorkItems -linkWorkItems $linkWorkItems -githubRepository $githubRepository -passPullRequestIdBackToADO $passPullRequestIdBackToADO -isForked $isForked -bypassPolicy $bypassPolicy -bypassReason $bypassReason
         }  
     }

--- a/task/createPullRequest.ps1
+++ b/task/createPullRequest.ps1
@@ -94,9 +94,9 @@ function RunTask {
         }
 
         foreach($branch in $targetBranches) {
-            $title = $title.Replace('[BRANCH_NAME]', $branch.Replace('/refs/heads/',''))
-            CreatePullRequest -teamProject $teamProject -repositoryName $repositoryName -sourceBranch $sourceBranch -targetBranch $branch -title $title -description $description -reviewers $reviewers -repoType $repoType -isDraft $isDraft -autoComplete $autoComplete -mergeStrategy $mergeStrategy -deleteSourch $deleteSourch -commitMessage $commitMessage -transitionWorkItems $transitionWorkItems -linkWorkItems $linkWorkItems -githubRepository $githubRepository -passPullRequestIdBackToADO $passPullRequestIdBackToADO -isForked $isForked -bypassPolicy $bypassPolicy -bypassReason $bypassReason
-        }  
+            $pullRequestTitle = $title.Replace('[BRANCH_NAME]', $branch.Replace('refs/heads/',''))
+            CreatePullRequest -teamProject $teamProject -repositoryName $repositoryName -sourceBranch $sourceBranch -targetBranch $branch -title $pullRequestTitle -description $description -reviewers $reviewers -repoType $repoType -isDraft $isDraft -autoComplete $autoComplete -mergeStrategy $mergeStrategy -deleteSourch $deleteSourch -commitMessage $commitMessage -transitionWorkItems $transitionWorkItems -linkWorkItems $linkWorkItems -githubRepository $githubRepository -passPullRequestIdBackToADO $passPullRequestIdBackToADO -isForked $isForked -bypassPolicy $bypassPolicy -bypassReason $bypassReason
+        }
     }
 
     finally {

--- a/task/createPullRequest.ps1
+++ b/task/createPullRequest.ps1
@@ -94,7 +94,7 @@ function RunTask {
         }
 
         foreach($branch in $targetBranches) {
-            $title = $title.Replace("[BRANCH_NAME]", $branch)
+            $title = $title.Replace('[BRANCH_NAME]', $branch.Replace('/refs/heads/',''))
             CreatePullRequest -teamProject $teamProject -repositoryName $repositoryName -sourceBranch $sourceBranch -targetBranch $branch -title $title -description $description -reviewers $reviewers -repoType $repoType -isDraft $isDraft -autoComplete $autoComplete -mergeStrategy $mergeStrategy -deleteSourch $deleteSourch -commitMessage $commitMessage -transitionWorkItems $transitionWorkItems -linkWorkItems $linkWorkItems -githubRepository $githubRepository -passPullRequestIdBackToADO $passPullRequestIdBackToADO -isForked $isForked -bypassPolicy $bypassPolicy -bypassReason $bypassReason
         }  
     }

--- a/task/task.json
+++ b/task/task.json
@@ -123,7 +123,7 @@
       "label": "Title",
       "defaultValue": "",
       "required": true,
-      "helpMarkDown": "The pull request title."
+      "helpMarkDown": "The pull request title. You can use the token [BRANCH_NAME] to dynamically reuse the current target branch name in the pull request title (for example: Merge master into [BRANCH_NAME])."
     },
     {
       "name": "description",


### PR DESCRIPTION
Hi again @shayki5, I have another proposition for a feature which I could leverage. This PR will allow to use a token in the PR title, like so:

title: Merge master into [BRANCH_NAME]

This would produce a dynamic replacement of the token after the current target branch name. Very useful when working multiple target branches. 
I edited also the helpMarkup for the `title` input to give an hint to the user on this feature.

I am kinda coding happy and your extension really helped me a lot, I am glad to contribute to it :)