### PR TITLE
Create branch if there are commits ahead compared to target branch

### DIFF
--- a/task/createPullRequest.ps1
+++ b/task/createPullRequest.ps1
@@ -437,7 +437,7 @@ function CheckIfThereAreChanges {
     $url = "$env:System_TeamFoundationCollectionUri$($teamProject)/_apis/git/repositories/$($repositoryName)/diffs/commits?baseVersion=$($sourceBranch)&targetVersion=$($targetBranch)&api-version=4.0&diffCommonCommit=false" + '&$top=2'
     $head = @{ Authorization = "Bearer $global:token" }
     $response = Invoke-RestMethod -Uri $url -Method Get -Headers $head -ContentType "application/json"
-    if ($response.behindCount -eq 0 -or '' -eq $response.changeCounts) {
+    if ($response.aheadCount -eq 0) {
         Write-Warning "***************************************************************"
         Write-Warning "There are no new changes in the source branch, no PR is needed!"
         Write-Warning "***************************************************************"

--- a/task/createPullRequest.ps1
+++ b/task/createPullRequest.ps1
@@ -20,7 +20,8 @@ function RunTask {
         [bool]$passPullRequestIdBackToADO,
         [bool]$isForked,
         [bool]$bypassPolicy,
-        [string]$bypassReason
+        [string]$bypassReason, 
+        [bool]$alwaysCreatePR
     )
 
     Trace-VstsEnteringInvocation $MyInvocation
@@ -46,6 +47,7 @@ function RunTask {
         $isForked = Get-VstsInput -Name 'isForked' -AsBool
         $bypassPolicy = Get-VstsInput -Name 'bypassPolicy' -AsBool
         $bypassReason = Get-VstsInput -Name 'bypassReason'
+        $alwaysCreatePR = Get-VstsInput -Name 'alwaysCreatePr'
         
         $global:token = (Get-VstsEndpoint -Name SystemVssConnection -Require).auth.parameters.AccessToken
 
@@ -96,7 +98,7 @@ function RunTask {
 
         foreach($branch in $targetBranches) {
             $pullRequestTitle = $title.Replace('[BRANCH_NAME]', $branch.Replace('refs/heads/',''))
-            CreatePullRequest -teamProject $teamProject -repositoryName $repositoryName -sourceBranch $sourceBranch -targetBranch $branch -title $pullRequestTitle -description $description -reviewers $reviewers -repoType $repoType -isDraft $isDraft -autoComplete $autoComplete -mergeStrategy $mergeStrategy -deleteSourch $deleteSourch -commitMessage $commitMessage -transitionWorkItems $transitionWorkItems -linkWorkItems $linkWorkItems -githubRepository $githubRepository -passPullRequestIdBackToADO $passPullRequestIdBackToADO -isForked $isForked -bypassPolicy $bypassPolicy -bypassReason $bypassReason
+            CreatePullRequest -teamProject $teamProject -repositoryName $repositoryName -sourceBranch $sourceBranch -targetBranch $branch -title $pullRequestTitle -description $description -reviewers $reviewers -repoType $repoType -isDraft $isDraft -autoComplete $autoComplete -mergeStrategy $mergeStrategy -deleteSourch $deleteSourch -commitMessage $commitMessage -transitionWorkItems $transitionWorkItems -linkWorkItems $linkWorkItems -githubRepository $githubRepository -passPullRequestIdBackToADO $passPullRequestIdBackToADO -isForked $isForked -bypassPolicy $bypassPolicy -bypassReason $bypassReason -alwaysCreatePR $alwaysCreatePR
         }
 
         if ($passPullRequestIdBackToADO) {
@@ -133,11 +135,12 @@ function CreatePullRequest() {
         [bool]$passPullRequestIdBackToADO,
         [bool]$isForked,
         [bool]$bypassPolicy,
-        [string]$bypassReason
+        [string]$bypassReason, 
+        [bool]$alwaysCreatePR
     )
 
     if ($repoType -eq "Azure DevOps") { 
-        CreateAzureDevOpsPullRequest -teamProject $teamProject -repositoryName $repositoryName -sourceBranch $sourceBranch -targetBranch $targetBranch -title $title -description $description -reviewers $reviewers -isDraft $isDraft -autoComplete $autoComplete -mergeStrategy $mergeStrategy -deleteSourch $deleteSourch -commitMessage $commitMessage -transitionWorkItems $transitionWorkItems -linkWorkItems $linkWorkItems -passPullRequestIdBackToADO $passPullRequestIdBackToADO -isForked $isForked -bypassPolicy $bypassPolicy -bypassReason $bypassReason
+        CreateAzureDevOpsPullRequest -teamProject $teamProject -repositoryName $repositoryName -sourceBranch $sourceBranch -targetBranch $targetBranch -title $title -description $description -reviewers $reviewers -isDraft $isDraft -autoComplete $autoComplete -mergeStrategy $mergeStrategy -deleteSourch $deleteSourch -commitMessage $commitMessage -transitionWorkItems $transitionWorkItems -linkWorkItems $linkWorkItems -passPullRequestIdBackToADO $passPullRequestIdBackToADO -isForked $isForked -bypassPolicy $bypassPolicy -bypassReason $bypassReason -alwaysCreatePR $alwaysCreatePR
     }
 
     else {
@@ -284,7 +287,8 @@ function CreateAzureDevOpsPullRequest() {
         [bool]$passPullRequestIdBackToADO,
         [bool]$isForked,
         [bool]$bypassPolicy,
-        [string]$bypassReason
+        [string]$bypassReason, 
+        [bool]$alwaysCreatePR
     )
 
     if (!$sourceBranch.Contains("refs")) {
@@ -308,7 +312,7 @@ function CreateAzureDevOpsPullRequest() {
     Write-Host "Bypass Reason: $bypassReason"
 
     if($isForked -eq $False) {
-        $changesExist = CheckIfThereAreChanges -sourceBranch $sourceBranch -targetBranch $targetBranch
+        $changesExist = CheckIfThereAreChanges -sourceBranch $sourceBranch -targetBranch $targetBranch -alwaysCreatePR $alwaysCreatePR
         if($changesExist -eq "false")
         {
             return
@@ -405,7 +409,8 @@ function CreateAzureDevOpsPullRequest() {
 function CheckIfThereAreChanges {
     Param (
         [string]$sourceBranch,
-        [string]$targetBranch
+        [string]$targetBranch, 
+        [bool]$alwaysCreatePR
     )
 
     # Remove the refs/heads/ or merge/pull from branches name (see issue #85)
@@ -437,7 +442,7 @@ function CheckIfThereAreChanges {
     $url = "$env:System_TeamFoundationCollectionUri$($teamProject)/_apis/git/repositories/$($repositoryName)/diffs/commits?baseVersion=$($sourceBranch)&targetVersion=$($targetBranch)&api-version=4.0&diffCommonCommit=false" + '&$top=2'
     $head = @{ Authorization = "Bearer $global:token" }
     $response = Invoke-RestMethod -Uri $url -Method Get -Headers $head -ContentType "application/json"
-    if ($response.aheadCount -eq 0) {
+    if ($alwaysCreatePR -eq $false -and ($response.behindCount -eq 0 -or '' -eq $response.changeCounts)) {
         Write-Warning "***************************************************************"
         Write-Warning "There are no new changes in the source branch, no PR is needed!"
         Write-Warning "***************************************************************"

--- a/task/task.json
+++ b/task/task.json
@@ -239,6 +239,15 @@
       "helpMarkDown": "If policies are bypassed, this reason is stored as to why bypass was used.",
       "groupName": "completion",
       "visibleRule": "bypassPolicy=true"
+    }, 
+    {
+      "name": "alwaysCreatePr",
+      "type": "boolean",
+      "label": "Always Create Pull Request",
+      "defaultValue": false,
+      "required": false,
+      "helpMarkDown": "If checked, a Pull Request will always be created even if there a no changed files.",
+      "visibleRule": "alwaysCreatePr=false"
     }
   ],
   "dataSourceBindings": [

--- a/task/task.json
+++ b/task/task.json
@@ -246,8 +246,7 @@
       "label": "Always Create Pull Request",
       "defaultValue": false,
       "required": false,
-      "helpMarkDown": "If checked, a Pull Request will always be created even if there a no changed files.",
-      "visibleRule": "alwaysCreatePr=false"
+      "helpMarkDown": "If checked, a Pull Request will always be created even if there a no changed files."
     }
   ],
   "dataSourceBindings": [


### PR DESCRIPTION
Instead of checking if the current branch ist behind or has actual file changes this check if there a commits ahead. 

In our case we have this scenario: 
```json
{
    "allChangesIncluded": true,
    "changeCounts": {},
    "changes": [],
    "commonCommit": "31743d6fe91e7678ff10b6b27aecae0712a6ec1c",
    "baseCommit": "31743d6fe91e7678ff10b6b27aecae0712a6ec1c",
    "targetCommit": "77f75073e53f30800b5efaee0a2ecb11f33ec08d",
    "aheadCount": 3,
    "behindCount": 0
}
```
So the source branch is 3 commits ahead, nothing behind and there is no changeCount, because the code file has the same change in source and target branch. 
To get the history and branches clean, it is necessary for me that the PR is created, completed and deleting the source branch. This is only possible with the check against the aheadCount. 