### PR TITLE
Add URI component escaping for branch names

### DIFF
--- a/task/createPullRequest.ps1
+++ b/task/createPullRequest.ps1
@@ -416,12 +416,8 @@ function CheckIfThereAreChanges {
        $targetBranch = $targetBranch.Remove(0, 10)
     }
     
-    if($sourceBranch -match "#"){
-        $sourceBranch = $sourceBranch.Replace('#','%23') 
-    }
-    if($targetBranch -match "#"){
-        $targetBranch = $targetBranch.Replace('#','%23') 
-    }
+    $sourceBranch = [uri]::EscapeDataString($sourceBranch)
+    $targetBranch = [uri]::EscapeDataString($targetBranch)
     
     $url = "$env:System_TeamFoundationCollectionUri$($teamProject)/_apis/git/repositories/$($repositoryName)/diffs/commits?baseVersion=$($sourceBranch)&targetVersion=$($targetBranch)&api-version=4.0" + '&$top=2'
     $head = @{ Authorization = "Bearer $global:token" }


### PR DESCRIPTION
Hi,

I just encountered an issue because one of our developers named a branch with a `+` :(. Even if it is a bad practice, it still is allowed by devops, hence I would like to propose this small fix by adding a call to `[uri]::EscapeDataString()` for both source and target branch names.