### PR TITLE
retry for bypassPR

### DIFF
--- a/task/createPullRequest.ps1
+++ b/task/createPullRequest.ps1
@@ -559,15 +559,18 @@ function CreateAzureDevOpsPullRequest() {
 
             # If set bypass is true 
             if ($bypassPolicy) {
+                $maxRetry = 2
+                $retryCounter = 1
+            
                 BypassPR -teamProject $teamProject -repositoryName $repositoryName -pullRequestId $pullRequestId -buildUserId $currentUserId -mergeStrategy $mergeStrategy -deleteSourch $deleteSourch -commitMessage $commitMessage -transitionWorkItems $transitionWorkItems -bypassPolicy $bypassPolicy -bypassReason $bypassReason
                 
                 GetPRData -teamProject $teamProject -repositoryName $repositoryName -pullRequestId $pullRequestId | Out-Null
-
-                if ($prData.status -ine "completed") {
+                while ($prData.status -ine "completed" -and $retryCounter -le $maxRetry) {
                     sleep 10
-                    Write-Host "Retry Bypass"            
+                    Write-Host "Retry Bypass: $retryCounter"
                     BypassPR -teamProject $teamProject -repositoryName $repositoryName -pullRequestId $pullRequestId -buildUserId $currentUserId -mergeStrategy $mergeStrategy -deleteSourch $deleteSourch -commitMessage $commitMessage -transitionWorkItems $transitionWorkItems -bypassPolicy $bypassPolicy -bypassReason $bypassReason
-                }
+                    $retryCounter++
+                } 
             }
         }
     }


### PR DESCRIPTION
The BypassPR doesn't always work every time with only 1 retry.
May I request to have the minimum changes and add additional 1 or 2 retries?

From the log, we can see this extension is creating the PR and attempting to bypass the PR twice:

```
*************************
******** Success ********
*************************
Pull Request 9929 created.
Get Data PR 9929.
Bypass PR 9929.
Get Data PR 9929.
Retry Bypass
Get Data PR 9929.
Bypass PR 9929.
```

However, the effort to bypass and complete the PR is not captured over here.
![image](https://user-images.githubusercontent.com/20835061/219319839-ce107dec-e1e8-435c-b899-b7c428f81825.png)
