### PR TITLE
get Azure DevOps reviewer id with api version 7.0

### DIFF
--- a/task/createPullRequest.ps1
+++ b/task/createPullRequest.ps1
@@ -745,9 +745,9 @@ function GetReviewerId() {
         # API reference: https://learn.microsoft.com/en-us/rest/api/azure/devops/ims/identities/read-identities?view=azure-devops-rest-7.0&tabs=HTTP
         Write-Debug $reviewers
         $reviewersId = @()
-        foreach ($reviewer in $reviewers.Split(';').Trim().ToLower()) {
-            $isRequired = $reviewer.StartsWith("req:")
-            $reviewer = $reviewer.Replace("req:", "")
+        foreach ($reviewer in $reviewers.Split(';').Trim()) {
+            $isRequired = $reviewer -imatch "^req:"
+            $reviewer = $reviewer -ireplace "^req:",""
             $searchFilter = if ($reviewer.Contains("@")) { "MailAddress" } else { "General" }
             $url = $url, "searchFilter=$searchFilter", "filterValue=$reviewer" -join "&"
             Write-Debug "Looking for identity of reviewer: $reviewer at $url"

--- a/task/createPullRequest.ps1
+++ b/task/createPullRequest.ps1
@@ -741,7 +741,7 @@ function GetReviewerId() {
     
     # If it's Azure DevOps
     else {
-        $url = $($env:System_TeamFoundationCollectionUri).Replace("visualstudio.com", "dev.azure.com").Replace("dev.azure.com", "vssps.dev.azure.com") + "_apis/identities?api-version=7.0"
+        $urlBase = $($env:System_TeamFoundationCollectionUri).Replace("visualstudio.com", "dev.azure.com").Replace("dev.azure.com", "vssps.dev.azure.com") + "_apis/identities?api-version=7.0"
         # API reference: https://learn.microsoft.com/en-us/rest/api/azure/devops/ims/identities/read-identities?view=azure-devops-rest-7.0&tabs=HTTP
         Write-Debug $reviewers
         $reviewersId = @()
@@ -749,7 +749,7 @@ function GetReviewerId() {
             $isRequired = $reviewer -imatch "^req:"
             $reviewer = $reviewer -ireplace "^req:",""
             $searchFilter = if ($reviewer.Contains("@")) { "MailAddress" } else { "General" }
-            $url = $url, "searchFilter=$searchFilter", "filterValue=$reviewer" -join "&"
+            $url = $urlBase, "searchFilter=$searchFilter", "filterValue=$reviewer" -join "&"
             Write-Debug "Looking for identity of reviewer: $reviewer at $url"
             $identities = Invoke-RestMethod -Uri $url -Method Get -ContentType application/json -Headers $head
             $idCount = $identities.count


### PR DESCRIPTION
The [User Entitlements API](https://learn.microsoft.com/en-us/rest/api/azure/devops/memberentitlementmanagement/user-entitlements/get?view=azure-devops-rest-4.1&tabs=HTTP) doesn't always give a complete list of all users in an organization -- in the case of my org, my identity is not found in user entitlements API response.

Azure DevOps REST API 7.0 offers an [Identities API](https://learn.microsoft.com/en-us/rest/api/azure/devops/ims/identities/read-identities?view=azure-devops-rest-7.0&tabs=HTTP) which supports looking up both users and teams.

This PR fixes the problem where some user id cannot be found. Plus, it skips unidentifiable reviewers in create PR POST request body, and writes a warning instead of passing along empty ids which can cause the whole task to fail.